### PR TITLE
Fix importing of tasks that have `depends` for task 2.6

### DIFF
--- a/examples/create_task.rs
+++ b/examples/create_task.rs
@@ -1,10 +1,10 @@
-extern crate task_hookrs;
 extern crate chrono;
 extern crate serde_json;
+extern crate task_hookrs;
 extern crate uuid;
 
-use task_hookrs::task::Task;
 use task_hookrs::status::TaskStatus;
+use task_hookrs::task::Task;
 use task_hookrs::uda::UDA;
 
 use chrono::NaiveDateTime;

--- a/examples/import_task.rs
+++ b/examples/import_task.rs
@@ -1,12 +1,12 @@
-extern crate task_hookrs;
 extern crate chrono;
 extern crate serde_json;
+extern crate task_hookrs;
 extern crate uuid;
 
 use std::io::stdin;
 
-use task_hookrs::status::TaskStatus;
 use task_hookrs::import::import;
+use task_hookrs::status::TaskStatus;
 
 fn main() {
     let mut tasks = import(stdin()).unwrap();

--- a/src/date.rs
+++ b/src/date.rs
@@ -8,13 +8,13 @@
 
 use std::ops::{Deref, DerefMut};
 
-use serde::Serialize;
-use serde::Serializer;
+use chrono::NaiveDateTime;
+use serde::de::Error as SerdeError;
+use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Deserializer;
-use serde::de::Visitor;
-use serde::de::Error as SerdeError;
-use chrono::NaiveDateTime;
+use serde::Serialize;
+use serde::Serializer;
 
 /// Date is a NaiveDateTime-Wrapper object to be able to implement foreign traits on it
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@
 /// Failure error kind type, defining error messages
 #[derive(Debug, Clone, Eq, PartialEq, Fail)]
 pub enum ErrorKind {
-
     /// Error kind indicating that the JSON parser failed
     #[fail(display = "Failed to create a Task from JSON")]
     ParserError,
@@ -24,6 +23,5 @@ pub enum ErrorKind {
 
     /// Error kind indicating that a conversion to JSON failed
     #[fail(display = "A Task could not be converted to JSON")]
-    SerializeError
+    SerializeError,
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
     unused_must_use,
     unused_mut,
     unused_qualifications,
-    while_true,
+    while_true
 )]
 
 extern crate chrono;
@@ -69,6 +69,6 @@ pub mod project;
 pub mod status;
 pub mod tag;
 pub mod task;
+pub mod tw;
 pub mod uda;
 pub mod urgency;
-pub mod tw;

--- a/src/status.rs
+++ b/src/status.rs
@@ -6,7 +6,7 @@
 
 //! Module containing `TaskStatus` type and trait impls
 
-use std::fmt::{Display, Formatter, Error as FmtError};
+use std::fmt::{Display, Error as FmtError, Formatter};
 
 /// Enum for status taskwarrior supports.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/src/task.rs
+++ b/src/task.rs
@@ -6,23 +6,23 @@
 
 //! Module containing `Task` type as well as trait implementations
 
-use std::result::Result as RResult;
 use std::fmt;
+use std::result::Result as RResult;
 
-use serde::{Serialize, Serializer};
+use chrono::Utc;
+use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer};
-use serde::de::{Visitor, Error, MapAccess};
+use serde::{Serialize, Serializer};
 use uuid::Uuid;
-use chrono::Utc;
 
-use priority::TaskPriority;
-use status::TaskStatus;
-use project::Project;
-use tag::Tag;
-use date::Date;
 use annotation::Annotation;
-use uda::{UDA, UDAName, UDAValue};
+use date::Date;
+use priority::TaskPriority;
+use project::Project;
+use status::TaskStatus;
+use tag::Tag;
+use uda::{UDAName, UDAValue, UDA};
 use urgency::Urgency;
 
 /// Task type
@@ -556,57 +556,57 @@ impl Serialize for Task {
         state.serialize_entry("entry", &self.entry)?;
         state.serialize_entry("description", &self.description)?;
 
-        self.annotations.as_ref().map(|v| {
-            state.serialize_entry("annotations", v)
-        });
+        self.annotations
+            .as_ref()
+            .map(|v| state.serialize_entry("annotations", v));
         self.tags.as_ref().map(|v| state.serialize_entry("tags", v));
         self.id.as_ref().map(|v| state.serialize_entry("id", v));
-        self.recur.as_ref().map(
-            |ref v| state.serialize_entry("recur", v),
-        );
+        self.recur
+            .as_ref()
+            .map(|ref v| state.serialize_entry("recur", v));
         self.depends.as_ref().map(|ref v| {
             let v: Vec<String> = v.iter().map(Uuid::to_string).collect();
             state.serialize_entry("depends", &v.join(","))
         });
-        self.due.as_ref().map(
-            |ref v| state.serialize_entry("due", v),
-        );
-        self.end.as_ref().map(
-            |ref v| state.serialize_entry("end", v),
-        );
-        self.imask.as_ref().map(
-            |ref v| state.serialize_entry("imask", v),
-        );
-        self.mask.as_ref().map(
-            |ref v| state.serialize_entry("mask", v),
-        );
-        self.modified.as_ref().map(|ref v| {
-            state.serialize_entry("modified", v)
-        });
-        self.parent.as_ref().map(|ref v| {
-            state.serialize_entry("parent", v)
-        });
-        self.priority.as_ref().map(|ref v| {
-            state.serialize_entry("priority", v)
-        });
-        self.project.as_ref().map(|ref v| {
-            state.serialize_entry("project", v)
-        });
-        self.scheduled.as_ref().map(|ref v| {
-            state.serialize_entry("scheduled", v)
-        });
-        self.start.as_ref().map(
-            |ref v| state.serialize_entry("start", v),
-        );
-        self.until.as_ref().map(
-            |ref v| state.serialize_entry("until", v),
-        );
-        self.wait.as_ref().map(
-            |ref v| state.serialize_entry("wait", v),
-        );
-        self.urgency.as_ref().map(
-            |ref v| state.serialize_entry("urgency", v),
-        );
+        self.due
+            .as_ref()
+            .map(|ref v| state.serialize_entry("due", v));
+        self.end
+            .as_ref()
+            .map(|ref v| state.serialize_entry("end", v));
+        self.imask
+            .as_ref()
+            .map(|ref v| state.serialize_entry("imask", v));
+        self.mask
+            .as_ref()
+            .map(|ref v| state.serialize_entry("mask", v));
+        self.modified
+            .as_ref()
+            .map(|ref v| state.serialize_entry("modified", v));
+        self.parent
+            .as_ref()
+            .map(|ref v| state.serialize_entry("parent", v));
+        self.priority
+            .as_ref()
+            .map(|ref v| state.serialize_entry("priority", v));
+        self.project
+            .as_ref()
+            .map(|ref v| state.serialize_entry("project", v));
+        self.scheduled
+            .as_ref()
+            .map(|ref v| state.serialize_entry("scheduled", v));
+        self.start
+            .as_ref()
+            .map(|ref v| state.serialize_entry("start", v));
+        self.until
+            .as_ref()
+            .map(|ref v| state.serialize_entry("until", v));
+        self.wait
+            .as_ref()
+            .map(|ref v| state.serialize_entry("wait", v));
+        self.urgency
+            .as_ref()
+            .map(|ref v| state.serialize_entry("urgency", v));
 
         for (key, value) in self.uda().iter() {
             state.serialize_entry(key, value)?;
@@ -627,7 +627,6 @@ impl<'de> Deserialize<'de> for Task {
             "uuid",
             "entry",
             "description",
-
             "annotations",
             "depends",
             "due",
@@ -807,7 +806,6 @@ impl<'de> Visitor<'de> for TaskDeserializeVisitor {
             uuid,
             entry,
             description,
-
             annotations,
             depends,
             due,
@@ -834,16 +832,16 @@ impl<'de> Visitor<'de> for TaskDeserializeVisitor {
 
 #[cfg(test)]
 mod test {
+    use annotation::Annotation;
     use date::Date;
     use date::TASKWARRIOR_DATETIME_TEMPLATE;
     use status::TaskStatus;
     use task::Task;
-    use annotation::Annotation;
     use uda::UDAValue;
 
-    use uuid::Uuid;
     use chrono::NaiveDateTime;
     use serde_json;
+    use uuid::Uuid;
 
     fn mklogger() {
         let _ = env_logger::init();
@@ -932,9 +930,7 @@ mod test {
 
         if let Some(tags) = task.tags() {
             for tag in tags {
-                let any_tag = ["some", "tags", "are", "here"].iter().any(
-                    |t| tag == *t,
-                );
+                let any_tag = ["some", "tags", "are", "here"].iter().any(|t| tag == *t);
                 assert!(any_tag, "Tag {} missing", tag);
             }
         } else {
@@ -960,9 +956,11 @@ mod test {
         assert!(back.contains("here"));
         assert!(back.contains("uuid"));
         assert!(back.contains("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0"));
-        assert!(back.contains(
-            "8ca953d5-18b4-4eb9-bd56-18f2e5b752f0,5a04bb1e-3f4b-49fb-b9ba-44407ca223b5",
-        ));
+        assert!(
+            back.contains(
+                "8ca953d5-18b4-4eb9-bd56-18f2e5b752f0,5a04bb1e-3f4b-49fb-b9ba-44407ca223b5",
+            )
+        );
     }
 
     #[test]
@@ -992,15 +990,14 @@ mod test {
 
         assert!(task.urgency() == Some(&-5.0));
 
-        let all_annotations =
-            vec![
-                Annotation::new(mkdate("20160423T125911Z"), String::from("An Annotation")),
-                Annotation::new(
-                    mkdate("20160423T125926Z"),
-                    String::from("Another Annotation")
-                ),
-                Annotation::new(mkdate("20160422T125942Z"), String::from("A Third Anno")),
-            ];
+        let all_annotations = vec![
+            Annotation::new(mkdate("20160423T125911Z"), String::from("An Annotation")),
+            Annotation::new(
+                mkdate("20160423T125926Z"),
+                String::from("Another Annotation"),
+            ),
+            Annotation::new(mkdate("20160422T125942Z"), String::from("A Third Anno")),
+        ];
 
         if let Some(annotations) = task.annotations() {
             for annotation in annotations {
@@ -1133,7 +1130,7 @@ mod test {
     #[test]
     fn test_builder_extensive() {
         use task::TaskBuilder;
-        use uda::{UDA, UDAValue};
+        use uda::{UDAValue, UDA};
         let mut uda = UDA::new();
         uda.insert(
             "test_str_uda".into(),
@@ -1173,12 +1170,10 @@ mod test {
     #[test]
     fn test_builder_defaults() {
         use task::TaskBuilder;
-        assert!(
-            TaskBuilder::default()
-                .description("Nice Task")
-                .build()
-                .is_ok()
-        );
+        assert!(TaskBuilder::default()
+            .description("Nice Task")
+            .build()
+            .is_ok());
     }
 
     #[test]
@@ -1186,5 +1181,4 @@ mod test {
         use task::TaskBuilder;
         assert!(TaskBuilder::default().build().is_err());
     }
-
 }

--- a/src/tw.rs
+++ b/src/tw.rs
@@ -4,21 +4,20 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-
 //! This module offers functions to interact with taskwarrior. This will expect the `task` binary
 //! in your path. This will always call task and never interact with your `.task` directory itself.
 //! (This is in accordance with the taskwarrior api guide lines.)
 
 use error::ErrorKind as EK;
-use task::Task;
-use std::process::{Command, Stdio, Child};
+use import::import;
 use std::io::Write;
 use std::iter::once;
-use import::import;
+use std::process::{Child, Command, Stdio};
+use task::Task;
 
-use serde_json;
 use failure::Fallible as Result;
 use failure::ResultExt;
+use serde_json;
 
 /// This will give you all tasks which match the given query in the taskwarrior query syntax.
 /// This is not sanitized. Never get the query string from an untrusted user.

--- a/src/uda.rs
+++ b/src/uda.rs
@@ -1,15 +1,15 @@
 //! Module containing the types for User Defined Attributes (UDA)
 
 use std::collections::BTreeMap;
-use std::result::Result as RResult;
 use std::fmt;
+use std::result::Result as RResult;
 
-use serde::Serialize;
-use serde::Serializer;
+use serde::de;
+use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Deserializer;
-use serde::de::Visitor;
-use serde::de;
+use serde::Serialize;
+use serde::Serializer;
 
 /// The name of a UDA is just a string.
 pub type UDAName = String;


### PR DESCRIPTION
So looks like the issue was that the export value of `depends` was changed from a string that contains values separated by a comma to a regular json array. Seen here: https://github.com/kdheepak/taskwarrior-tui/issues/277#issuecomment-939695463 

This means we can remove our custom code for (de)serializing `depends` and fallback to default serde behaviour.

This pr also contains a commit that runs `cargo fmt` on the project